### PR TITLE
Fix configmap naming not being unique

### DIFF
--- a/examples/backup/main.tf
+++ b/examples/backup/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "pvc" {
   source  = "dgdelahera/pvc-restic/kubernetes"
-  version = "1.2.0"
+  version = "1.3.0"
 
   pvc = {
     name = local.pvc_name

--- a/examples/restore/main.tf
+++ b/examples/restore/main.tf
@@ -1,6 +1,6 @@
 module "pvc" {
   source  = "dgdelahera/pvc-restic/kubernetes"
-  version = "1.2.0"
+  version = "1.3.0"
 
   pvc = {
     name = "example-restore"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "kubernetes_secret_v1" "backup_config" {
 
 resource "kubernetes_config_map_v1" "backup_script" {
   metadata {
-    name      = "backup-script"
+    name      = "backup-pvc-${var.pvc.name}"
     namespace = var.pvc.namespace
   }
   data = {


### PR DESCRIPTION
This was causing conflicts when creating multiple
PVCs in the same namespace.